### PR TITLE
you forgot to specify default user_id and event_type  parameter value

### DIFF
--- a/lib/amplitude-api/event.rb
+++ b/lib/amplitude-api/event.rb
@@ -15,14 +15,14 @@ class AmplitudeAPI
     # @param [ String ] user_id a user_id to associate with the event
     # @param [ String ] event_type a name for the event
     # @param [ Hash ] event_properties various properties to attach to the event
-    def initialize(user_id: , event_type: , event_properties: {})
+    def initialize(user_id:{} , event_type: {}, event_properties: {})
       self.user_id = user_id
       self.event_type = event_type
       self.event_properties = event_properties
     end
 
     def user_id=(value)
-      @user_id = 
+      @user_id =
         if value.respond_to?(:id)
           value.id
         else

--- a/lib/amplitude-api/event.rb
+++ b/lib/amplitude-api/event.rb
@@ -15,7 +15,7 @@ class AmplitudeAPI
     # @param [ String ] user_id a user_id to associate with the event
     # @param [ String ] event_type a name for the event
     # @param [ Hash ] event_properties various properties to attach to the event
-    def initialize(user_id:{} , event_type: {}, event_properties: {})
+    def initialize(user_id: "" , event_type: "", event_properties: {})
       self.user_id = user_id
       self.event_type = event_type
       self.event_properties = event_properties

--- a/spec/lib/amplitude_api_spec.rb
+++ b/spec/lib/amplitude_api_spec.rb
@@ -30,6 +30,26 @@ describe AmplitudeAPI do
     end
   end
 
+  describe ".initializer " do
+    it "initializes event without parameter" do
+      event = AmplitudeAPI::Event.new()
+      expect(event.to_hash).to eq({
+        event_type: "",
+        user_id: "",
+        event_properties: {}
+      })
+    end
+
+    it "initializes event with parameter" do
+      event = AmplitudeAPI::Event.new(user_id: 123, event_type: "test_event", event_properties: {test_property: 1})
+      expect(event.to_hash).to eq({
+        event_type: "test_event",
+        user_id: 123,
+        event_properties: {test_property: 1}
+      })
+    end
+  end
+
   describe ".send_event" do
     it "sends an event to AmplitudeAPI" do
       event = AmplitudeAPI::Event.new(user_id: @user, event_type: "test_event", event_properties: {test_property: 1})


### PR DESCRIPTION
When I install your api and start my server, I have  this error:
 SyntaxError: /Library/Ruby/Gems/2.0.0/gems/amplitude-api-0.0.2/lib/amplitude-api/event.rb:18: syntax error, unexpected ','
    def initialize(user_id: , event_type: , event_properties: {})
I assume that your forgot to specify default value ti initialize function