### PR TITLE
Add Identify API

### DIFF
--- a/lib/amplitude-api.rb
+++ b/lib/amplitude-api.rb
@@ -2,10 +2,11 @@ require 'json'
 require 'bundler/setup'
 require 'typhoeus'
 require 'amplitude-api/event'
+require 'amplitude-api/identification'
 
 class AmplitudeAPI
   TRACK_URI_STRING = "https://api.amplitude.com/httpapi"
-  IDENTIFY_URI_STRING = "https://api.amplitude.com/"
+  IDENTIFY_URI_STRING = "https://api.amplitude.com/identify"
 
   USER_WITH_NO_ACCOUNT = "user who doesn't have an account"
 

--- a/lib/amplitude-api.rb
+++ b/lib/amplitude-api.rb
@@ -25,6 +25,11 @@ class AmplitudeAPI
       track(event)
     end
 
+    def send_identify(user_id, properties = {})
+      identify = AmplitudeAPI::Identify.new(user_id, properties)
+      # Send identify request here
+    end
+
     # @overload body(event)
     #   @param [ AmplitudeAPI::Event ]
     #
@@ -51,7 +56,7 @@ class AmplitudeAPI
     # @overload track([events])
     #   @param [ Array<AmplitudeAPI::Event> ] Send an array of events in a single request to Amplitude
     #
-    # @return [ Typhoeus::Response ] 
+    # @return [ Typhoeus::Response ]
     #
     # Send one or more Events to the Amplitude API
     def track(*events)

--- a/lib/amplitude-api/identification.rb
+++ b/lib/amplitude-api/identification.rb
@@ -1,5 +1,5 @@
 class AmplitudeAPI
-  class Identify
+  class Identification
     def initialize(user_id: "", user_properties: {})
       self.user_id = user_id
       self.user_properties = user_properties

--- a/lib/amplitude-api/identification.rb
+++ b/lib/amplitude-api/identification.rb
@@ -1,10 +1,33 @@
 class AmplitudeAPI
   class Identification
+    # @!attribute [ rw ] user_id
+    #   @return [ String ] the user_id to be sent to Amplitude
+    attr_accessor :user_id
+    # @!attribute [ rw ] user_properties
+    #   @return [ String ] the user_properties to be attached to the Amplitude Identify
+    attr_accessor :user_properties
+
+    # Create a new Identification
+    #
+    # @param [ String ] user_id a user_id to associate with the identification
+    # @param [ Hash ] user_properties various properties to attach to the user identification
     def initialize(user_id: "", user_properties: {})
       self.user_id = user_id
       self.user_properties = user_properties
     end
 
+    def user_id=(value)
+      @user_id =
+        if value.respond_to?(:id)
+          value.id
+        else
+          value || AmplitudeAPI::USER_WITH_NO_ACCOUNT
+        end
+    end
+
+    # @return [ Hash ] A serialized Event
+    #
+    # Used for serialization and comparison
     def to_hash
       {
         user_id: self.user_id,

--- a/lib/amplitude-api/identification.rb
+++ b/lib/amplitude-api/identification.rb
@@ -34,5 +34,16 @@ class AmplitudeAPI
         user_properties: self.user_properties
       }
     end
+
+    # @return [ true, false ]
+    #
+    # Compares +to_hash+ for equality
+    def ==(other)
+      if other.respond_to?(:to_hash)
+        self.to_hash == other.to_hash
+      else
+        false
+      end
+    end
   end
 end

--- a/lib/amplitude-api/identify.rb
+++ b/lib/amplitude-api/identify.rb
@@ -1,0 +1,15 @@
+class AmplitudeAPI
+  class Identify
+    def initialize(user_id: "", user_properties: {})
+      self.user_id = user_id
+      self.user_properties = user_properties
+    end
+
+    def to_hash
+      {
+        user_id: self.user_id,
+        user_properties: self.user_properties
+      }
+    end
+  end
+end

--- a/spec/lib/amplitude-api/identification_spec.rb
+++ b/spec/lib/amplitude-api/identification_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe AmplitudeAPI::Identification do
+  User = Struct.new(:id)
+
+  context "with a user object" do
+    describe "#body" do
+      it "populates with the user's id" do
+        identification = AmplitudeAPI::Identification.new(user_id: User.new(123))
+        expect(identification.to_hash[:user_id]).to eq(123)
+      end
+    end
+  end
+
+  context "with a user id" do
+    describe "#body" do
+      it "populates with the user's id" do
+        identification = AmplitudeAPI::Identification.new(user_id: 123)
+        expect(identification.to_hash[:user_id]).to eq(123)
+      end
+    end
+  end
+
+  context "without a user" do
+    describe "#body" do
+      it "populates with the unknown user" do
+        identification = AmplitudeAPI::Identification.new(user_id: nil)
+        expect(identification.to_hash[:user_id]).to eq(AmplitudeAPI::USER_WITH_NO_ACCOUNT)
+      end
+    end
+  end
+
+  describe '#body' do
+    it "includes the user id" do
+      identification = AmplitudeAPI::Identification.new(user_id: 123)
+      expect(identification.to_hash[:user_id]).to eq(123)
+    end
+
+    it "includes arbitrary user properties" do
+      identification = AmplitudeAPI::Identification.new(user_id: 123, user_properties: {first_name: 'John', last_name: 'Doe'})
+      expect(identification.to_hash[:user_properties]).to eq(first_name: 'John', last_name: 'Doe')
+    end
+  end
+end

--- a/spec/lib/amplitude_api_spec.rb
+++ b/spec/lib/amplitude_api_spec.rb
@@ -30,6 +30,31 @@ describe AmplitudeAPI do
     end
   end
 
+  describe ".identify" do
+    context "with a single identification" do
+      it "sends the identification to Amplitude" do
+        identification = AmplitudeAPI::Identification.new(user_id: 123, user_properties: {first_name: 'John', last_name: 'Doe'})
+        body = {api_key: AmplitudeAPI.api_key, identification: JSON.generate([identification.to_hash])}
+
+        expect(Typhoeus).to receive(:post).with(AmplitudeAPI::IDENTIFY_URI_STRING, body: body)
+
+        AmplitudeAPI.identify(identification)
+      end
+    end
+
+    context "with multiple identifications" do
+      it "sends all identifications in a single request" do
+        identification = AmplitudeAPI::Identification.new(user_id: 123, user_properties: {first_name: 'Julian', last_name: 'Ponce'})
+        identification2 = AmplitudeAPI::Identification.new(user_id: 456, user_properties: {first_name: 'John', last_name: 'Doe'})
+        body = {api_key: AmplitudeAPI.api_key, identification: JSON.generate([identification.to_hash, identification2.to_hash])}
+
+        expect(Typhoeus).to receive(:post).with(AmplitudeAPI::IDENTIFY_URI_STRING, body: body)
+
+        AmplitudeAPI.identify([identification, identification2])
+      end
+    end
+  end
+
   describe ".initializer " do
     it "initializes event without parameter" do
       event = AmplitudeAPI::Event.new()
@@ -73,6 +98,33 @@ describe AmplitudeAPI do
         expect(AmplitudeAPI).to receive(:track).with(event)
 
         AmplitudeAPI.send_event("test_event", @user.id, test_property: 1)
+      end
+    end
+  end
+
+  describe ".send_identify" do
+    it "sends an identify to AmplitudeAPI" do
+      identification = AmplitudeAPI::Identification.new(user_id: @user, user_properties: {first_name: 'John', last_name: 'Doe'})
+      expect(AmplitudeAPI).to receive(:identify).with(identification)
+
+      AmplitudeAPI.send_identify(@user, {first_name: 'John', last_name: 'Doe'})
+    end
+
+    context "the user is nil" do
+      it "sends an identify with the no account user" do
+        identification = AmplitudeAPI::Identification.new(user_id: nil, user_properties: {first_name: 'John', last_name: 'Doe'})
+        expect(AmplitudeAPI).to receive(:identify).with(identification)
+
+        AmplitudeAPI.send_identify(nil, {first_name: 'John', last_name: 'Doe'})
+      end
+    end
+
+    context "the user is a user_id" do
+      it "sends an identify to AmplitudeAPI" do
+        identification = AmplitudeAPI::Identification.new(user_id: 123, user_properties: {first_name: 'John', last_name: 'Doe'})
+        expect(AmplitudeAPI).to receive(:identify).with(identification)
+
+        AmplitudeAPI.send_identify(@user.id, {first_name: 'John', last_name: 'Doe'})
       end
     end
   end

--- a/spec/lib/amplitude_api_spec.rb
+++ b/spec/lib/amplitude_api_spec.rb
@@ -11,7 +11,7 @@ describe AmplitudeAPI do
         event = AmplitudeAPI::Event.new(user_id: 123, event_type: 'clicked on sign up')
         body = {api_key: AmplitudeAPI.api_key, event: JSON.generate([event.to_hash])}
 
-        expect(Typhoeus).to receive(:post).with(AmplitudeAPI::URI_STRING, body: body)
+        expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, body: body)
 
         AmplitudeAPI.track(event)
       end
@@ -23,7 +23,7 @@ describe AmplitudeAPI do
         event2 = AmplitudeAPI::Event.new(user_id: 456, event_type: 'liked a widget')
         body = {api_key: AmplitudeAPI.api_key, event: JSON.generate([event.to_hash, event2.to_hash])}
 
-        expect(Typhoeus).to receive(:post).with(AmplitudeAPI::URI_STRING, body: body)
+        expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, body: body)
 
         AmplitudeAPI.track([event, event2])
       end
@@ -80,13 +80,13 @@ describe AmplitudeAPI do
   describe "#body" do
     it "should add an api key" do
       event = AmplitudeAPI::Event.new(user_id: @user, event_type: "test_event", event_properties: {test_property: 1})
-      body = AmplitudeAPI.body(event)
+      body = AmplitudeAPI.track_body(event)
       expect(body[:api_key]).to eq('stub api key')
     end
 
     it "should create an event" do
       event = AmplitudeAPI::Event.new(user_id: 23, event_type: "test_event", event_properties: {foo: "bar"})
-      body = AmplitudeAPI.body(event)
+      body = AmplitudeAPI.track_body(event)
 
       expected = JSON.generate([{event_type: "test_event", user_id: 23, event_properties: {foo: "bar"}}])
       expect(body[:event]).to eq(expected)


### PR DESCRIPTION
https://amplitude.zendesk.com/hc/en-us/articles/205406617-Identify-API-Modify-User-Properties

Added Identify feature. This allows us to set user properties before generating the events.

I abstracted the logic to another class: `AmplitudeAPI::Identification` instead of polluting `AmplitudeAPI::Event` with user_properties.