### PR TITLE
Add support for user_properties when sending events

### DIFF
--- a/lib/amplitude_api.rb
+++ b/lib/amplitude_api.rb
@@ -22,15 +22,18 @@ class AmplitudeAPI
     #
     # @param [ String ] event_name a string that describes the event, e.g. "clicked on Home"
     # @param [ String ] user a string or integer that uniquely identifies a user.
-    # @param [ Hash ] properties a hash that is serialized to JSON,
+    # @param [ Hash ] event_properties a hash that is serialized to JSON,
     # and can contain any other property to be stored on the Event
+    # @param [ Hash ] user_properties a hash that is serialized to JSON,
+    # and contains user properties to be associated with the user
     #
     # @return [ Typhoeus::Response ]
-    def send_event(event_name, user, properties = {})
+    def send_event(event_name, user, event_properties: {}, user_properties: {})
       event = AmplitudeAPI::Event.new(
         user_id: user,
         event_type: event_name,
-        event_properties: properties
+        event_properties: event_properties,
+        user_properties: user_properties
       )
       track(event)
     end

--- a/lib/amplitude_api/event.rb
+++ b/lib/amplitude_api/event.rb
@@ -10,6 +10,9 @@ class AmplitudeAPI
     # @!attribute [ rw ] event_properties
     #   @return [ String ] the event_properties to be attached to the Amplitude Event
     attr_accessor :event_properties
+    # @!attribute [ rw ] user_properties
+    #   @return [ String ] the user_properties to be passed for the user
+    attr_accessor :user_properties
     # @!attribute [ rw ] time
     #   @return [ Time ] Time that the event occurred (defaults to now)
     attr_accessor :time
@@ -20,10 +23,11 @@ class AmplitudeAPI
     # @param [ String ] event_type a name for the event
     # @param [ Hash ] event_properties various properties to attach to the event
     # @param [ Time ] Time that the event occurred (defaults to now)
-    def initialize(user_id: '', event_type: '', event_properties: {}, time: nil)
+    def initialize(user_id: '', event_type: '', event_properties: {}, user_properties: {}, time: nil)
       self.user_id = user_id
       self.event_type = event_type
       self.event_properties = event_properties
+      self.user_properties = user_properties
       self.time = time
     end
 
@@ -44,6 +48,7 @@ class AmplitudeAPI
       serialized_event[:event_type] = event_type
       serialized_event[:user_id] = user_id
       serialized_event[:event_properties] = event_properties
+      serialized_event[:user_properties] = user_properties
       serialized_event[:time] = formatted_time if time
       serialized_event
     end

--- a/spec/lib/amplitude_api_spec.rb
+++ b/spec/lib/amplitude_api_spec.rb
@@ -98,7 +98,8 @@ describe AmplitudeAPI do
       expect(event.to_hash).to eq(
         event_type: '',
         user_id: '',
-        event_properties: {}
+        event_properties: {},
+        user_properties: {}
       )
     end
 
@@ -113,7 +114,8 @@ describe AmplitudeAPI do
       expect(event.to_hash).to eq(
         event_type: 'test_event',
         user_id: 123,
-        event_properties: { test_property: 1 }
+        event_properties: { test_property: 1 },
+        user_properties: {}
       )
     end
   end
@@ -127,7 +129,7 @@ describe AmplitudeAPI do
       )
       expect(described_class).to receive(:track).with(event)
 
-      described_class.send_event('test_event', user, test_property: 1)
+      described_class.send_event('test_event', user, event_properties: {test_property: 1})
     end
 
     context 'the user is nil' do
@@ -139,7 +141,7 @@ describe AmplitudeAPI do
         )
         expect(described_class).to receive(:track).with(event)
 
-        described_class.send_event('test_event', nil, test_property: 1)
+        described_class.send_event('test_event', nil, event_properties: {test_property: 1})
       end
     end
 
@@ -152,7 +154,24 @@ describe AmplitudeAPI do
         )
         expect(described_class).to receive(:track).with(event)
 
-        described_class.send_event('test_event', user.id, test_property: 1)
+        described_class.send_event('test_event', user.id, event_properties: {test_property: 1})
+      end
+
+      it 'sends arbitrary user_properties to AmplitudeAPI' do
+        event = AmplitudeAPI::Event.new(
+          user_id: 123,
+          event_type: 'test_event',
+          event_properties: { test_property: 1 },
+          user_properties: { test_user_property: 'abc' }
+        )
+        expect(described_class).to receive(:track).with(event)
+
+        described_class.send_event(
+          'test_event',
+          user.id,
+          event_properties: {test_property: 1},
+          user_properties: { test_user_property: 'abc' }
+        )
       end
     end
   end
@@ -221,6 +240,9 @@ describe AmplitudeAPI do
         event_type: 'test_event',
         event_properties: {
           foo: 'bar'
+        },
+        user_properties: {
+          abc: '123'
         }
       )
       body = described_class.track_body(event)
@@ -232,6 +254,9 @@ describe AmplitudeAPI do
             user_id: 23,
             event_properties: {
               foo: 'bar'
+            },
+            user_properties: {
+              abc: '123'
             }
           }
         ]


### PR DESCRIPTION
Using https://amplitude.zendesk.com/hc/en-us/articles/207908967-How-to-Analyze-A-B-Tests-Split-Tests-Results-in-Amplitude as a reference I was trying to send `user_properties` along with arbitrary events using the gem. The API supports it (https://amplitude.zendesk.com/hc/en-us/articles/204771828-HTTP-API), this just parameterizes the arguments to accept event/user properties.

Specs pass here, happy to tweak/add anything. Thanks for the gem!