### PR TITLE
Updated readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,10 +20,10 @@ AmplitudeAPI.api_key = "abcdef123456"
 event = AmplitudeAPI::Event.new({
   user_id: "123",
   event_type: "clicked on home",
+  time: Time.now,
   event_properties: {
     cause: "button",
-    arbitrary: "properties",
-    time: Time.now
+    arbitrary: "properties"
   }
 })
 AmplitudeAPI.track(event)

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ gem install amplitude-api
 
 ## Basic Usage
 
-The following code snippet will immediately track an event to the Amplitude API. The time on the event will automatically be the time of the request.
+The following code snippet will immediately track an event to the Amplitude API.
 
 ```ruby
 # Configure your Amplitude API key
@@ -22,7 +22,8 @@ event = AmplitudeAPI::Event.new({
   event_type: "clicked on home",
   event_properties: {
     cause: "button",
-    arbitrary: "properties"
+    arbitrary: "properties",
+    time: Time.now
   }
 })
 AmplitudeAPI.track(event)


### PR DESCRIPTION
Added `time` event_property so it's obvious how to change the time of the event.

I needed to import my historical events, and had to check out issues to figure out how to do it.
It would be better to put this right into example. Bonus point is that we don't need to explain this `The time on the event will automatically be the time of the request.`