### PR TITLE
Add IP property for event

### DIFF
--- a/lib/amplitude_api.rb
+++ b/lib/amplitude_api.rb
@@ -28,12 +28,12 @@ class AmplitudeAPI
     # and contains user properties to be associated with the user
     #
     # @return [ Typhoeus::Response ]
-    def send_event(event_name, user, event_properties: {}, user_properties: {})
+    def send_event(event_name, user, options = {})
       event = AmplitudeAPI::Event.new(
         user_id: user,
         event_type: event_name,
-        event_properties: event_properties,
-        user_properties: user_properties
+        event_properties: options.fetch(:event_properties, {}),
+        user_properties: options.fetch(:user_properties, {})
       )
       track(event)
     end

--- a/lib/amplitude_api/event.rb
+++ b/lib/amplitude_api/event.rb
@@ -16,6 +16,9 @@ class AmplitudeAPI
     # @!attribute [ rw ] time
     #   @return [ Time ] Time that the event occurred (defaults to now)
     attr_accessor :time
+    # @!attribute [ rw ] ip
+    #   @return [ String ] IP address of the user
+    attr_accessor :ip
 
     # Create a new Event
     #
@@ -23,12 +26,14 @@ class AmplitudeAPI
     # @param [ String ] event_type a name for the event
     # @param [ Hash ] event_properties various properties to attach to the event
     # @param [ Time ] Time that the event occurred (defaults to now)
-    def initialize(user_id: '', event_type: '', event_properties: {}, user_properties: {}, time: nil)
-      self.user_id = user_id
-      self.event_type = event_type
-      self.event_properties = event_properties
-      self.user_properties = user_properties
-      self.time = time
+    # @param [ String ] IP address of the user
+    def initialize(options = {})
+      self.user_id = options.fetch(:user_id, '')
+      self.event_type = options.fetch(:event_type, '')
+      self.event_properties = options.fetch(:event_properties, {})
+      self.user_properties = options.fetch(:user_properties, {})
+      self.time = options[:time]
+      self.ip = options.fetch(:ip, '')
     end
 
     def user_id=(value)
@@ -50,6 +55,7 @@ class AmplitudeAPI
       serialized_event[:event_properties] = event_properties
       serialized_event[:user_properties] = user_properties
       serialized_event[:time] = formatted_time if time
+      serialized_event[:ip] = ip if ip
       serialized_event
     end
 

--- a/spec/lib/amplitude_api_spec.rb
+++ b/spec/lib/amplitude_api_spec.rb
@@ -99,7 +99,8 @@ describe AmplitudeAPI do
         event_type: '',
         user_id: '',
         event_properties: {},
-        user_properties: {}
+        user_properties: {},
+        ip: ''
       )
     end
 
@@ -109,13 +110,15 @@ describe AmplitudeAPI do
         event_type: 'test_event',
         event_properties: {
           test_property: 1
-        }
+        },
+        ip: '8.8.8.8'
       )
       expect(event.to_hash).to eq(
         event_type: 'test_event',
         user_id: 123,
         event_properties: { test_property: 1 },
-        user_properties: {}
+        user_properties: {},
+        ip: '8.8.8.8'
       )
     end
   end
@@ -243,7 +246,8 @@ describe AmplitudeAPI do
         },
         user_properties: {
           abc: '123'
-        }
+        },
+        ip: '8.8.8.8'
       )
       body = described_class.track_body(event)
 
@@ -257,7 +261,8 @@ describe AmplitudeAPI do
             },
             user_properties: {
               abc: '123'
-            }
+            },
+            ip: '8.8.8.8'
           }
         ]
       )


### PR DESCRIPTION
User IP address very useful property for segment users by Country, City, Region.

![amplitude_analytics](https://cloud.githubusercontent.com/assets/36139/15633123/6c04bdf2-25ae-11e6-88d4-f4f207cb05f1.jpg)
