### PR TITLE
Add insert_id property for event

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 cache: bundler
 rvm:
+  - 2.3.1
   - 2.2.2
   - 2.1.6

--- a/lib/amplitude_api/event.rb
+++ b/lib/amplitude_api/event.rb
@@ -20,6 +20,10 @@ class AmplitudeAPI
     #   @return [ String ] IP address of the user
     attr_accessor :ip
 
+    # @!attribute [ rw ] insert_id
+    #   @return [ String ] the unique identifier to be sent to Amplitude
+    attr_accessor :insert_id
+
     # @!attribute [ rw ] price
     #   @return [ String ] (required for revenue data) price of the item purchased
     attr_accessor :price
@@ -46,6 +50,8 @@ class AmplitudeAPI
     # @param [ Integer ] quantity (optional, but required for revenue data) quantity of the item purchased
     # @param [ String ] product_id (optional) an identifier for the product.
     # @param [ String ] revenue_type (optional) type of revenue
+    # @param [ String ] IP address of the user
+    # @param [ String ] insert_id a unique identifier for the event
     def initialize(options = {})
       self.user_id = options.fetch(:user_id, '')
       self.event_type = options.fetch(:event_type, '')
@@ -53,6 +59,7 @@ class AmplitudeAPI
       self.user_properties = options.fetch(:user_properties, {})
       self.time = options[:time]
       self.ip = options.fetch(:ip, '')
+      self.insert_id = options[:insert_id]
       validate_revenue_arguments(options)
     end
 
@@ -76,6 +83,7 @@ class AmplitudeAPI
       serialized_event[:user_properties] = user_properties
       serialized_event[:time] = formatted_time if time
       serialized_event[:ip] = ip if ip
+      serialized_event[:insert_id] = insert_id if insert_id
 
       serialized_event.merge(revenue_hash)
     end

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ event = AmplitudeAPI::Event.new({
   user_id: "123",
   event_type: "clicked on home",
   time: Time.now,
+  insert_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
   event_properties: {
     cause: "button",
     arbitrary: "properties"
@@ -40,7 +41,7 @@ Currently, we are using this in Rails and using ActiveJob to dispatch events asy
 ## Other useful resources
 * [Amplitude HTTP Api Documentation](https://amplitude.zendesk.com/hc/en-us/articles/204771828)
 * [Segment.io Amplitude integration](https://segment.com/docs/integrations/amplitude/)
- 
+
 ## Contributing
 
 I'd love to hear how you're using this. Please check out the [issues](https://github.com/toothrot/amplitude-api/issues).

--- a/spec/lib/amplitude_api/event_spec.rb
+++ b/spec/lib/amplitude_api/event_spec.rb
@@ -101,6 +101,25 @@ describe AmplitudeAPI::Event do
       end
     end
 
+    describe 'insert_id' do
+      it 'includes an insert_id for the event' do
+        event = described_class.new(
+          user_id: 123,
+          event_type: 'clicked on home',
+          insert_id: 'foo-bar'
+        )
+        expect(event.to_hash[:insert_id]).to eq('foo-bar')
+      end
+
+      it 'does not include insert_id if it is not set' do
+        event = described_class.new(
+          user_id: 123,
+          event_type: 'clicked on home'
+        )
+        expect(event.to_hash).not_to have_key(:insert_id)
+      end
+    end
+
     describe 'revenue params' do
       it 'includes the price if it is set' do
         price = 100_000.99


### PR DESCRIPTION
According to documentation: https://amplitude.zendesk.com/hc/en-us/articles/204771828-HTTP-API

> insert_id string a unique identifier for the event being inserted; we will deduplicate events with the same insert_id sent within 24 hours of each other
