### PR TITLE
Support `platform` and `country` event parameters

### DIFF
--- a/lib/amplitude_api.rb
+++ b/lib/amplitude_api.rb
@@ -1,11 +1,13 @@
 require 'json'
 require 'bundler/setup'
 require 'typhoeus'
-require_relative 'amplitude_api/event'
-require_relative 'amplitude_api/identification'
 
 # AmplitudeAPI
 class AmplitudeAPI
+  require_relative 'amplitude_api/config'
+  require_relative 'amplitude_api/event'
+  require_relative 'amplitude_api/identification'
+
   TRACK_URI_STRING        = 'https://api.amplitude.com/httpapi'.freeze
   IDENTIFY_URI_STRING     = 'https://api.amplitude.com/identify'.freeze
   SEGMENTATION_URI_STRING = 'https://amplitude.com/api/2/events/segmentation'.freeze
@@ -13,13 +15,21 @@ class AmplitudeAPI
   USER_WITH_NO_ACCOUNT = "user who doesn't have an account".freeze
 
   class << self
-    # @!attribute [ rw ] api_key
-    #   @return [ String ] an Amplitude API Key
-    attr_accessor :api_key
+    def config
+      Config.instance
+    end
 
-    # @!attribute [ rw ] secret_key
-    #   @return [ String ] an Amplitude Secret Key
-    attr_accessor :secret_key
+    def configure
+      yield config
+    end
+
+    def api_key
+      config.api_key
+    end
+
+    def secret_key
+      config.secret_key
+    end
 
     # ==== Event Tracking related methods
 

--- a/lib/amplitude_api/config.rb
+++ b/lib/amplitude_api/config.rb
@@ -1,0 +1,30 @@
+require 'singleton'
+
+class AmplitudeAPI
+  # AmplitudeAPI::Config
+  class Config
+    include Singleton
+
+    attr_accessor :api_key, :secret_key, :whitelist, :time_formatter,
+                  :event_properties_formatter, :user_properties_formatter
+
+    def initialize
+      self.class.defaults.each { |k, v| send("#{k}=", v) }
+    end
+
+    class << self
+      def defaults
+        {
+          api_key: nil,
+          secret_key: nil,
+          whitelist: %i(user_id device_id event_type time
+            event_properties user_properties time ip platform country insert_id
+            revenue_type price quantity product_id),
+          time_formatter: ->(time) { time ? time.to_i * 1_000 : nil },
+          event_properties_formatter: ->(props) { props || {} },
+          user_properties_formatter: ->(props) { props || {} }
+        }
+      end
+    end
+  end
+end

--- a/lib/amplitude_api/event.rb
+++ b/lib/amplitude_api/event.rb
@@ -22,6 +22,12 @@ class AmplitudeAPI
     # @!attribute [ rw ] ip
     #   @return [ String ] IP address of the user
     attr_accessor :ip
+    # @!attribute [ rw ] platform
+    #   @return [ String ] the platform of the device.
+    attr_accessor :platform
+    # @!attribute [ rw ] country
+    #   @return [ String ] the country the user is in.
+    attr_accessor :country
 
     # @!attribute [ rw ] insert_id
     #   @return [ String ] the unique identifier to be sent to Amplitude
@@ -55,6 +61,8 @@ class AmplitudeAPI
     # @param [ String ] product_id (optional) an identifier for the product.
     # @param [ String ] revenue_type (optional) type of revenue
     # @param [ String ] IP address of the user
+    # @param [ String ] platform the platform of the device (e.g. iOS, Android, Web)
+    # @param [ String ] country the country the user is in
     # @param [ String ] insert_id a unique identifier for the event
     def initialize(attributes = {})
       self.user_id = getopt(attributes, :user_id, '')
@@ -64,6 +72,8 @@ class AmplitudeAPI
       self.user_properties = getopt(attributes, :user_properties, {})
       self.time = getopt(attributes, :time)
       self.ip = getopt(attributes, :ip, '')
+      self.platform = getopt(attributes, :platform, nil)
+      self.country = getopt(attributes, :country, nil)
       self.insert_id = getopt(attributes, :insert_id)
       validate_revenue_arguments(attributes)
     end
@@ -95,6 +105,8 @@ class AmplitudeAPI
       serialized_event[:device_id] = device_id if device_id
       serialized_event[:time] = formatted_time if time
       serialized_event[:ip] = ip if ip
+      serialized_event[:platform] = platform if platform
+      serialized_event[:country] = country if country
       serialized_event[:insert_id] = insert_id if insert_id
       serialized_event
     end

--- a/spec/lib/amplitude_api/event_spec.rb
+++ b/spec/lib/amplitude_api/event_spec.rb
@@ -42,7 +42,7 @@ describe AmplitudeAPI::Event do
   describe 'init' do
     context 'attributes' do
       it 'accepts string attributes' do
-        time = Time.parse('2016-01-01 00:00:00 -0000')
+        time = Time.at(1_451_606_400_000 / 1_000)
         event = described_class.new(
           'user_id' => 123,
           'device_id' => 'abcd',
@@ -61,11 +61,13 @@ describe AmplitudeAPI::Event do
                                     user_properties: { 'c' => 'd' },
                                     time: 1_451_606_400_000,
                                     ip: '127.0.0.1',
+                                    platform: 'Web',
+                                    country: 'United States',
                                     insert_id: 'bestId')
       end
 
       it 'accepts symbol attributes' do
-        time = Time.parse('2016-01-01 00:00:00 -0000')
+        time = Time.at(1_451_606_400_000 / 1_000)
         event = described_class.new(
           user_id: 123,
           device_id: 'abcd',
@@ -131,7 +133,7 @@ describe AmplitudeAPI::Event do
 
     describe 'time' do
       it 'includes a time for the event' do
-        time = Time.parse('2016-01-01 00:00:00 -0000')
+        time = Time.at(1_451_606_400_000 / 1_000)
         event = described_class.new(
           user_id: 123,
           event_type: 'clicked on home',

--- a/spec/lib/amplitude_api/event_spec.rb
+++ b/spec/lib/amplitude_api/event_spec.rb
@@ -51,6 +51,8 @@ describe AmplitudeAPI::Event do
           'user_properties' => { 'c' => 'd' },
           'time' => time,
           'ip' => '127.0.0.1',
+          'platform' => 'Web',
+          'country' => 'United States',
           'insert_id' => 'bestId'
         )
 
@@ -76,6 +78,8 @@ describe AmplitudeAPI::Event do
           user_properties: { 'c' => 'd' },
           time: time,
           ip: '127.0.0.1',
+          platform: 'Web',
+          country: 'United States',
           insert_id: 'bestId'
         )
 
@@ -86,6 +90,8 @@ describe AmplitudeAPI::Event do
                                     user_properties: { 'c' => 'd' },
                                     time: 1_451_606_400_000,
                                     ip: '127.0.0.1',
+                                    platform: 'Web',
+                                    country: 'United States',
                                     insert_id: 'bestId')
       end
     end
@@ -167,6 +173,44 @@ describe AmplitudeAPI::Event do
           event_type: 'clicked on home'
         )
         expect(event.to_hash).not_to have_key(:insert_id)
+      end
+    end
+
+    describe 'platform' do
+      it 'includes the platform for the event' do
+        event = described_class.new(
+          user_id: 123,
+          event_type: 'clicked on home',
+          platform: 'Web'
+        )
+        expect(event.to_hash[:platform]).to eq('Web')
+      end
+
+      it 'does not include the platform if it is not set' do
+        event = described_class.new(
+          user_id: 123,
+          event_type: 'clicked on home'
+        )
+        expect(event.to_hash).not_to have_key(:platform)
+      end
+    end
+
+    describe 'country' do
+      it 'includes the country for the event' do
+        event = described_class.new(
+          user_id: 123,
+          event_type: 'clicked on home',
+          country: 'United States'
+        )
+        expect(event.to_hash[:country]).to eq('United States')
+      end
+
+      it 'does not include the country if it is not set' do
+        event = described_class.new(
+          user_id: 123,
+          event_type: 'clicked on home'
+        )
+        expect(event.to_hash).not_to have_key(:country)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,6 @@ RSpec.configure do |config|
   config.order = 'random'
 
   config.before(:suite) do
-    AmplitudeAPI.api_key = 'stub api key'
+    AmplitudeAPI.config.api_key = 'stub api key'
   end
 end


### PR DESCRIPTION
In addition, this should fix the build issues with `Time.parse` not being a valid function (it's no longer part of the Ruby standard library).