### PR TITLE
Remove bundler/setup since it breaks bundle inline

### DIFF
--- a/lib/amplitude_api.rb
+++ b/lib/amplitude_api.rb
@@ -1,5 +1,4 @@
 require 'json'
-require 'bundler/setup'
 require 'typhoeus'
 
 # AmplitudeAPI


### PR DESCRIPTION
Requiring bundler/setup breaks the ability to allow usage of bundler inline.

Example of usage:

```
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'amplitude-api'
end

require 'amplitude_api'

puts AmplitudeAPI::VERSION
```