### PR TITLE
Update docs to reflect new syntax for configuring the API key.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,8 @@ The following code snippet will immediately track an event to the Amplitude API.
 
 ```ruby
 # Configure your Amplitude API key
-AmplitudeAPI.api_key = "abcdef123456"
+AmplitudeAPI.config.api_key = "abcdef123456"
+
 
 event = AmplitudeAPI::Event.new({
   user_id: "123",


### PR DESCRIPTION
Update the syntax in the documentation for the API key configuration
Fixes: https://github.com/toothrot/amplitude-api/issues/32