### PR TITLE
Loosen Typhoeus constraint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # Generated from /Users/alex/development/amplitude-api/amplitude-api.gemspec
 source 'https://rubygems.org'
 
-gem 'typhoeus', '~> 1.0.2'
+gem 'typhoeus', '~> 1.0'
 
 group :development, :test do
   gem 'pry', '~> 0.9.12.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ DEPENDENCIES
   rspec (>= 2.99.0)
   rubocop (~> 0.37.2)
   rubocop-rspec
-  typhoeus (~> 1.0.2)
+  typhoeus (~> 1.0)
 
 BUNDLED WITH
    1.10.6

--- a/amplitude-api.gemspec
+++ b/amplitude-api.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 2.99', '>= 2.99.0'
   spec.add_development_dependency 'rake', '~> 10.0', '>= 10.0'
   spec.add_development_dependency 'pry', '~> 0.9.12.6'
-  spec.add_dependency 'typhoeus', '~> 1.0.2'
+  spec.add_dependency 'typhoeus', '~> 1.0'
   spec.required_ruby_version = '~> 2.0'
 end


### PR DESCRIPTION
As discussed in #26 which was never merged the constraint `~> 1.0` will allow for any 1.x version of the `typhoeus` gem.