### PR TITLE
Fix issues with multiple IDs in Delete API

### DIFF
--- a/lib/amplitude_api.rb
+++ b/lib/amplitude_api.rb
@@ -168,22 +168,35 @@ class AmplitudeAPI
     #
     # You must pass in either an array of user_ids or an array of amplitude_ids
     #
-    # @param [ user_ids ] (optional) the user_ids to delete
+    # @param [ Array<String> ] (optional) the user_ids to delete
     # based on your database
-    # @param [ amplitude_ids ] (optional) the amplitude_ids to delete
+    # @param [ Array<Integer> ] (optional) the amplitude_ids to delete
     # based on the amplitude database
     # @param [ String ] requester the email address of the person who
     # is requesting the deletion, optional but useful for reporting
     #
     # @return [ Typhoeus::Response ]
     def delete(user_ids: nil, amplitude_ids: nil, requester: nil)
-      Typhoeus.post DELETION_URI_STRING,
-                    userpwd: "#{api_key}:#{config.secret_key}",
-                    body: {
-                      amplitude_ids: amplitude_ids,
-                      user_ids: user_ids,
-                      requester: requester
-                    }.delete_if { |_, value| value.nil? }
+      user_ids = Array(user_ids)
+      amplitude_ids = Array(amplitude_ids)
+      Typhoeus.post(
+        DELETION_URI_STRING,
+        userpwd: "#{api_key}:#{config.secret_key}",
+        body: delete_body(user_ids, amplitude_ids, requester),
+        headers: { 'Content-Type': 'application/json' }
+      )
+    end
+
+    private
+
+    def delete_body(user_ids, amplitude_ids, requester)
+      JSON.generate(
+        {
+          amplitude_ids: amplitude_ids,
+          user_ids: user_ids,
+          requester: requester
+        }.delete_if { |_, value| value.nil? || value.empty? }
+      )
     end
   end
 end

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ event = AmplitudeAPI::Event.new({
 AmplitudeAPI.track(event)
 ```
 
-## GDPR Compliance
+## User Privacy APIs
 
 The following code snippet will delete a user from amplitude
 
@@ -43,11 +43,12 @@ AmplitudeAPI.config.api_key = "abcdef123456"
 AmplitudeAPI.config.secret_key = "secretMcSecret"
 
 AmplitudeAPI.delete(user_ids: [233],
-  requester: "privacy@mycompany.com"
+  requester: "privacy@example.com"
 )
 ```
 
-Currently, we are using this in Rails and using ActiveJob to dispatch events asynchronously. I plan on moving background/asynchronous support into this gem.
+Currently, we are using this in Rails and using ActiveJob to dispatch events asynchronously. I plan on moving 
+background/asynchronous support into this gem.
 
 ## What's Next
 

--- a/spec/lib/amplitude_api_spec.rb
+++ b/spec/lib/amplitude_api_spec.rb
@@ -376,6 +376,22 @@ describe AmplitudeAPI do
   end
 
   describe '.delete' do
+    context 'a single user_id' do
+      it 'correctly formats the response' do
+        body = {
+          user_ids: ['123']
+        }
+
+        expect(Typhoeus).to receive(:post).with(
+          AmplitudeAPI::DELETION_URI_STRING,
+          userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
+          body: JSON.generate(body),
+          headers: { 'Content-Type': 'application/json' }
+        )
+        described_class.delete(user_ids: '123')
+      end
+    end
+
     context 'with user_ids' do
       it 'sends the deletion to Amplitude' do
         user_ids =  [123, 456, 555]
@@ -386,7 +402,8 @@ describe AmplitudeAPI do
         expect(Typhoeus).to receive(:post).with(
           AmplitudeAPI::DELETION_URI_STRING,
           userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
-          body: body
+          body: JSON.generate(body),
+          headers: { 'Content-Type': 'application/json' }
         )
         described_class.delete(user_ids: user_ids)
       end
@@ -396,14 +413,15 @@ describe AmplitudeAPI do
           user_ids =  [123, 456, 555]
           amplitude_ids = [122, 456]
           body = {
-            user_ids: user_ids,
-            amplitude_ids: amplitude_ids
+            amplitude_ids: amplitude_ids,
+            user_ids: user_ids
           }
 
           expect(Typhoeus).to receive(:post).with(
             AmplitudeAPI::DELETION_URI_STRING,
             userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
-            body: body
+            body: JSON.generate(body),
+            headers: { 'Content-Type': 'application/json' }
           )
           described_class.delete(
             amplitude_ids: amplitude_ids,
@@ -423,9 +441,26 @@ describe AmplitudeAPI do
         expect(Typhoeus).to receive(:post).with(
           AmplitudeAPI::DELETION_URI_STRING,
           userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
-          body: body
+          body: JSON.generate(body),
+          headers: { 'Content-Type': 'application/json' }
         )
         described_class.delete(amplitude_ids: amplitude_ids)
+      end
+    end
+
+    context 'a single amplitude_id' do
+      it 'correctly formats the response' do
+        body = {
+          amplitude_ids: [122]
+        }
+
+        expect(Typhoeus).to receive(:post).with(
+          AmplitudeAPI::DELETION_URI_STRING,
+          userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
+          body: JSON.generate(body),
+          headers: { 'Content-Type': 'application/json' }
+        )
+        described_class.delete(amplitude_ids: 122)
       end
     end
 
@@ -439,9 +474,12 @@ describe AmplitudeAPI do
         }
         userpwd = "#{described_class.api_key}:#{described_class.config.secret_key}"
 
-        expect(Typhoeus).to receive(:post).with(AmplitudeAPI::DELETION_URI_STRING,
-                                                userpwd: userpwd,
-                                                body: body)
+        expect(Typhoeus).to receive(:post).with(
+          AmplitudeAPI::DELETION_URI_STRING,
+          userpwd: userpwd,
+          body: JSON.generate(body),
+          headers: { 'Content-Type': 'application/json' }
+        )
         described_class.delete(
           amplitude_ids: amplitude_ids,
           requester: 'privacy@gethopscotch.com'


### PR DESCRIPTION
Our code was incorrectly failing to specify application/json as the
content type, and the receiving API was failing to parse our response.

Fixes #41