### PR TITLE
Add timeout configuration option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Amplitude API Changelog
 
-We would like to think our many [contributors](https://github.com/toothrot/amplitude-api/graphs/contributors) for
+We would like to thank our many [contributors](https://github.com/toothrot/amplitude-api/graphs/contributors) for
 suggestions, ideas and improvements to Amplitude API.
 
 ## 0.1.1 (2019-01-01)

--- a/lib/amplitude_api/config.rb
+++ b/lib/amplitude_api/config.rb
@@ -6,7 +6,8 @@ class AmplitudeAPI
     include Singleton
 
     attr_accessor :api_key, :secret_key, :whitelist, :time_formatter,
-                  :event_properties_formatter, :user_properties_formatter
+                  :event_properties_formatter, :user_properties_formatter,
+                  :timeout, :connecttimeout
 
     def initialize
       self.class.defaults.each { |k, v| send("#{k}=", v) }
@@ -22,7 +23,9 @@ class AmplitudeAPI
                         revenue_type price quantity product_id],
           time_formatter: ->(time) { time ? time.to_i * 1_000 : nil },
           event_properties_formatter: ->(props) { props || {} },
-          user_properties_formatter: ->(props) { props || {} }
+          user_properties_formatter: ->(props) { props || {} },
+          timeout: 0,
+          connecttimeout: 0
         }
       end
     end

--- a/spec/lib/amplitude_api_spec.rb
+++ b/spec/lib/amplitude_api_spec.rb
@@ -17,7 +17,8 @@ describe AmplitudeAPI do
             event: JSON.generate([event.to_hash])
           }
 
-          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, body: body)
+          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, timeout: 0, connecttimeout: 0,
+                                                                                  body: body)
 
           described_class.track(event)
         end
@@ -34,7 +35,8 @@ describe AmplitudeAPI do
             event: JSON.generate([event.to_hash])
           }
 
-          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, body: body)
+          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, timeout: 0, connecttimeout: 0,
+                                                                                  body: body)
 
           described_class.track(event)
         end
@@ -52,7 +54,8 @@ describe AmplitudeAPI do
             event: JSON.generate([event.to_hash])
           }
 
-          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, body: body)
+          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, timeout: 0, connecttimeout: 0,
+                                                                                  body: body)
 
           described_class.track(event)
         end
@@ -74,7 +77,8 @@ describe AmplitudeAPI do
           event: JSON.generate([event.to_hash, event2.to_hash])
         }
 
-        expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, body: body)
+        expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, timeout: 0, connecttimeout: 0,
+                                                                                body: body)
 
         described_class.track([event, event2])
       end
@@ -97,7 +101,8 @@ describe AmplitudeAPI do
             identification: JSON.generate([identification.to_hash])
           }
 
-          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::IDENTIFY_URI_STRING, body: body)
+          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::IDENTIFY_URI_STRING, timeout: 0, connecttimeout: 0,
+                                                                                     body: body)
 
           described_class.identify(identification)
         end
@@ -117,7 +122,8 @@ describe AmplitudeAPI do
             identification: JSON.generate([identification.to_hash])
           }
 
-          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::IDENTIFY_URI_STRING, body: body)
+          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::IDENTIFY_URI_STRING, timeout: 0, connecttimeout: 0,
+                                                                                     body: body)
 
           described_class.identify(identification)
         end
@@ -138,7 +144,8 @@ describe AmplitudeAPI do
             identification: JSON.generate([identification.to_hash])
           }
 
-          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::IDENTIFY_URI_STRING, body: body)
+          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::IDENTIFY_URI_STRING, timeout: 0, connecttimeout: 0,
+                                                                                     body: body)
 
           described_class.identify(identification)
         end
@@ -166,7 +173,8 @@ describe AmplitudeAPI do
           identification: JSON.generate([identification.to_hash, identification2.to_hash])
         }
 
-        expect(Typhoeus).to receive(:post).with(AmplitudeAPI::IDENTIFY_URI_STRING, body: body)
+        expect(Typhoeus).to receive(:post).with(AmplitudeAPI::IDENTIFY_URI_STRING, timeout: 0, connecttimeout: 0,
+                                                                                   body: body)
 
         described_class.identify([identification, identification2])
       end
@@ -362,6 +370,8 @@ describe AmplitudeAPI do
 
     it 'sends request to Amplitude' do
       expect(Typhoeus).to receive(:get).with(AmplitudeAPI::SEGMENTATION_URI_STRING,
+                                             timeout: 0,
+                                             connecttimeout: 0,
                                              userpwd: "#{described_class.api_key}:#{described_class.secret_key}",
                                              params: {
                                                e: { event_type: 'my event' }.to_json,
@@ -384,6 +394,8 @@ describe AmplitudeAPI do
 
         expect(Typhoeus).to receive(:post).with(
           AmplitudeAPI::DELETION_URI_STRING,
+          timeout: 0,
+          connecttimeout: 0,
           userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
           body: JSON.generate(body),
           headers: { 'Content-Type': 'application/json' }
@@ -401,6 +413,8 @@ describe AmplitudeAPI do
 
         expect(Typhoeus).to receive(:post).with(
           AmplitudeAPI::DELETION_URI_STRING,
+          timeout: 0,
+          connecttimeout: 0,
           userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
           body: JSON.generate(body),
           headers: { 'Content-Type': 'application/json' }
@@ -419,6 +433,8 @@ describe AmplitudeAPI do
 
           expect(Typhoeus).to receive(:post).with(
             AmplitudeAPI::DELETION_URI_STRING,
+            timeout: 0,
+            connecttimeout: 0,
             userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
             body: JSON.generate(body),
             headers: { 'Content-Type': 'application/json' }
@@ -440,6 +456,8 @@ describe AmplitudeAPI do
 
         expect(Typhoeus).to receive(:post).with(
           AmplitudeAPI::DELETION_URI_STRING,
+          timeout: 0,
+          connecttimeout: 0,
           userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
           body: JSON.generate(body),
           headers: { 'Content-Type': 'application/json' }
@@ -456,6 +474,8 @@ describe AmplitudeAPI do
 
         expect(Typhoeus).to receive(:post).with(
           AmplitudeAPI::DELETION_URI_STRING,
+          timeout: 0,
+          connecttimeout: 0,
           userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
           body: JSON.generate(body),
           headers: { 'Content-Type': 'application/json' }
@@ -476,6 +496,8 @@ describe AmplitudeAPI do
 
         expect(Typhoeus).to receive(:post).with(
           AmplitudeAPI::DELETION_URI_STRING,
+          timeout: 0,
+          connecttimeout: 0,
           userpwd: userpwd,
           body: JSON.generate(body),
           headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
What do you think about making HTTP request timeouts configurable?
Recently we had an incident where amplitude was having issues and it caused queue delays and some service degradation. 
Shorter timeouts would enable us to fail faster and let sidekiq exponential backoff's handle it.

This PR adds the options based on the [typhoeus guide](https://github.com/typhoeus/typhoeus#timeouts), it passes through configurable timeout and connect timeout options to typheous HTTP requests.

Regarding the defaults:

> The default timeout is 0 (zero) which means curl never times out  during transfer. The default connecttimeout is 300 seconds. A connecttimeout of 0 will also result in the default connecttimeout of 300 seconds.

I am not sure how could we test timeouts in the unit tests 🤔 Let me know if you have ideas and I can experiment. with it.

2 rubocop checks are failing 😬 I didn't want to go ahead and add local ignore or changing the rubocop rules without consulting you... What approach do you prefer to fix them?