### PR TITLE
Update the Gem to point to HTTP API V2

### DIFF
--- a/lib/amplitude_api.rb
+++ b/lib/amplitude_api.rb
@@ -9,7 +9,7 @@ class AmplitudeAPI
   require_relative 'amplitude_api/event'
   require_relative 'amplitude_api/identification'
 
-  TRACK_URI_STRING        = 'https://api.amplitude.com/httpapi'
+  TRACK_URI_STRING        = 'https://api.amplitude.com/2/httpapi'
   IDENTIFY_URI_STRING     = 'https://api.amplitude.com/identify'
   SEGMENTATION_URI_STRING = 'https://amplitude.com/api/2/events/segmentation'
   DELETION_URI_STRING     = 'https://amplitude.com/api/2/deletions/users'
@@ -72,7 +72,7 @@ class AmplitudeAPI
 
       {
         api_key: api_key,
-        event: JSON.generate(event_body)
+        events: JSON.generate(event_body)
       }
     end
 
@@ -86,7 +86,10 @@ class AmplitudeAPI
     #
     # Send one or more Events to the Amplitude API
     def track(*events)
-      Typhoeus.post(TRACK_URI_STRING, body: track_body(events))
+      Typhoeus.post(
+        TRACK_URI_STRING,
+        headers: { 'Content-Type': 'application/json' },
+        body: track_body(events))
     end
 
     # ==== Identification related methods

--- a/lib/amplitude_api.rb
+++ b/lib/amplitude_api.rb
@@ -70,10 +70,10 @@ class AmplitudeAPI
     def track_body(*events)
       event_body = events.flatten.map(&:to_hash)
 
-      {
+      JSON.generate({
         api_key: api_key,
-        events: JSON.generate(event_body)
-      }
+        events: event_body
+      })
     end
 
     # @overload track(event)
@@ -88,7 +88,7 @@ class AmplitudeAPI
     def track(*events)
       Typhoeus.post(
         TRACK_URI_STRING,
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type' => 'application/json' },
         body: track_body(events))
     end
 
@@ -188,7 +188,7 @@ class AmplitudeAPI
         DELETION_URI_STRING,
         userpwd: "#{api_key}:#{config.secret_key}",
         body: delete_body(user_ids, amplitude_ids, requester),
-        headers: { 'Content-Type': 'application/json' }
+        headers: { 'Content-Type' => 'application/json' }
       )
     end
 

--- a/spec/lib/amplitude_api_spec.rb
+++ b/spec/lib/amplitude_api_spec.rb
@@ -14,11 +14,11 @@ describe AmplitudeAPI do
             user_id: 123,
             event_type: 'clicked on sign up'
           )
-          body = {
+          body = JSON.generate({
             api_key: described_class.api_key,
-            events: JSON.generate([event.to_hash])
-          }
-          headers = { 'Content-Type': 'application/json' }
+            events: [event.to_hash]
+          })
+          headers = { 'Content-Type' => 'application/json' }
 
           expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
 
@@ -32,11 +32,11 @@ describe AmplitudeAPI do
             device_id: device_id,
             event_type: 'clicked on sign up'
           )
-          body = {
+          body = JSON.generate({
             api_key: described_class.api_key,
-            events: JSON.generate([event.to_hash])
-          }
-          headers = { 'Content-Type': 'application/json' }
+            events: [event.to_hash]
+          })
+          headers = { 'Content-Type' => 'application/json' }
 
           expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
 
@@ -51,11 +51,11 @@ describe AmplitudeAPI do
             device_id: device_id,
             event_type: 'clicked on sign up'
           )
-          body = {
+          body = JSON.generate({
             api_key: described_class.api_key,
-            events: JSON.generate([event.to_hash])
-          }
-          headers = { 'Content-Type': 'application/json' }
+            events: [event.to_hash]
+          })
+          headers = { 'Content-Type' => 'application/json' }
 
           expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
 
@@ -74,11 +74,11 @@ describe AmplitudeAPI do
           user_id: 456,
           event_type: 'liked a widget'
         )
-        body = {
+        body = JSON.generate({
           api_key: described_class.api_key,
-          events: JSON.generate([event.to_hash, event2.to_hash])
-        }
-        headers = { 'Content-Type': 'application/json' }
+          events: [event.to_hash, event2.to_hash]
+        })
+        headers = { 'Content-Type' => 'application/json' }
 
         expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
 
@@ -392,7 +392,7 @@ describe AmplitudeAPI do
           AmplitudeAPI::DELETION_URI_STRING,
           userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
           body: JSON.generate(body),
-          headers: { 'Content-Type': 'application/json' }
+          headers: { 'Content-Type' => 'application/json' }
         )
         described_class.delete(user_ids: '123')
       end
@@ -409,7 +409,7 @@ describe AmplitudeAPI do
           AmplitudeAPI::DELETION_URI_STRING,
           userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
           body: JSON.generate(body),
-          headers: { 'Content-Type': 'application/json' }
+          headers: { 'Content-Type' => 'application/json' }
         )
         described_class.delete(user_ids: user_ids)
       end
@@ -427,7 +427,7 @@ describe AmplitudeAPI do
             AmplitudeAPI::DELETION_URI_STRING,
             userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
             body: JSON.generate(body),
-            headers: { 'Content-Type': 'application/json' }
+            headers: { 'Content-Type' => 'application/json' }
           )
           described_class.delete(
             amplitude_ids: amplitude_ids,
@@ -448,7 +448,7 @@ describe AmplitudeAPI do
           AmplitudeAPI::DELETION_URI_STRING,
           userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
           body: JSON.generate(body),
-          headers: { 'Content-Type': 'application/json' }
+          headers: { 'Content-Type' => 'application/json' }
         )
         described_class.delete(amplitude_ids: amplitude_ids)
       end
@@ -464,7 +464,7 @@ describe AmplitudeAPI do
           AmplitudeAPI::DELETION_URI_STRING,
           userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
           body: JSON.generate(body),
-          headers: { 'Content-Type': 'application/json' }
+          headers: { 'Content-Type' => 'application/json' }
         )
         described_class.delete(amplitude_ids: 122)
       end
@@ -484,7 +484,7 @@ describe AmplitudeAPI do
           AmplitudeAPI::DELETION_URI_STRING,
           userpwd: userpwd,
           body: JSON.generate(body),
-          headers: { 'Content-Type': 'application/json' }
+          headers: { 'Content-Type' => 'application/json' }
         )
         described_class.delete(
           amplitude_ids: amplitude_ids,
@@ -503,8 +503,9 @@ describe AmplitudeAPI do
           test_property: 1
         }
       )
-      body = described_class.track_body(event)
-      expect(body[:api_key]).to eq('stub api key')
+      json_body = described_class.track_body(event)
+      body = JSON.parse(json_body)
+      expect(body["api_key"]).to eq('stub api key')
     end
 
     it 'creates an event' do
@@ -519,8 +520,8 @@ describe AmplitudeAPI do
         },
         ip: '8.8.8.8'
       )
-      body = described_class.track_body(event)
-
+      json_body = described_class.track_body(event)
+      body = JSON.parse(json_body, symbolize_names: true)
       expected = [
         {
           event_type: 'test_event',
@@ -534,7 +535,7 @@ describe AmplitudeAPI do
           ip: '8.8.8.8'
         }
       ]
-      expect(JSON.parse(body[:events], symbolize_names: true)).to eq(expected)
+      expect(body[:events]).to eq(expected)
     end
   end
 end

--- a/spec/lib/amplitude_api_spec.rb
+++ b/spec/lib/amplitude_api_spec.rb
@@ -16,10 +16,11 @@ describe AmplitudeAPI do
           )
           body = {
             api_key: described_class.api_key,
-            event: JSON.generate([event.to_hash])
+            events: JSON.generate([event.to_hash])
           }
+          headers = { 'Content-Type': 'application/json' }
 
-          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, body: body)
+          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
 
           described_class.track(event)
         end
@@ -33,10 +34,11 @@ describe AmplitudeAPI do
           )
           body = {
             api_key: described_class.api_key,
-            event: JSON.generate([event.to_hash])
+            events: JSON.generate([event.to_hash])
           }
+          headers = { 'Content-Type': 'application/json' }
 
-          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, body: body)
+          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
 
           described_class.track(event)
         end
@@ -51,10 +53,11 @@ describe AmplitudeAPI do
           )
           body = {
             api_key: described_class.api_key,
-            event: JSON.generate([event.to_hash])
+            events: JSON.generate([event.to_hash])
           }
+          headers = { 'Content-Type': 'application/json' }
 
-          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, body: body)
+          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
 
           described_class.track(event)
         end
@@ -73,10 +76,11 @@ describe AmplitudeAPI do
         )
         body = {
           api_key: described_class.api_key,
-          event: JSON.generate([event.to_hash, event2.to_hash])
+          events: JSON.generate([event.to_hash, event2.to_hash])
         }
+        headers = { 'Content-Type': 'application/json' }
 
-        expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, body: body)
+        expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
 
         described_class.track([event, event2])
       end
@@ -530,7 +534,7 @@ describe AmplitudeAPI do
           ip: '8.8.8.8'
         }
       ]
-      expect(JSON.parse(body[:event], symbolize_names: true)).to eq(expected)
+      expect(JSON.parse(body[:events], symbolize_names: true)).to eq(expected)
     end
   end
 end


### PR DESCRIPTION
The HTTP API which this gem currently uses is deprecated, but the changes required to get update to HTTP API V2 were minimal:

1. Change the endpoint
2. Set the `Content-Type: application/json` header for POST requests
3. Pluralize the `event` key in the request

This PR makes those changes.

The changes and improvements are documented here:
https://help.amplitude.com/hc/en-us/articles/360032842391#http-api-v2-improvements
