### PR TITLE
Allow sending session_id

### DIFF
--- a/lib/amplitude_api/config.rb
+++ b/lib/amplitude_api/config.rb
@@ -20,7 +20,7 @@ class AmplitudeAPI
           api_key: nil,
           secret_key: nil,
           whitelist: %i[user_id device_id event_type time
-                        event_properties user_properties time ip platform country insert_id
+                        event_properties user_properties time ip platform country insert_id session_id
                         revenue_type price quantity product_id],
           time_formatter: ->(time) { time ? time.to_i * 1_000 : nil },
           event_properties_formatter: ->(props) { props || {} },

--- a/lib/amplitude_api/event.rb
+++ b/lib/amplitude_api/event.rb
@@ -44,7 +44,7 @@ class AmplitudeAPI
 
     # @return [ Hash ] Optional properties
     def optional_properties
-      %i[device_id time ip platform country insert_id].map do |prop|
+      %i[device_id time ip platform country insert_id session_id].map do |prop|
         val = prop == :time ? formatted_time : send(prop)
         val ? [prop, val] : nil
       end.compact.to_h

--- a/spec/lib/amplitude_api/event_spec.rb
+++ b/spec/lib/amplitude_api/event_spec.rb
@@ -55,7 +55,8 @@ describe AmplitudeAPI::Event do
           'ip' => '127.0.0.1',
           'platform' => 'Web',
           'country' => 'United States',
-          'insert_id' => 'bestId'
+          'insert_id' => 'bestId',
+          'session_id' => 'mySessionId',
         )
 
         expect(event.to_hash).to eq(event_type: 'sausage',
@@ -67,7 +68,8 @@ describe AmplitudeAPI::Event do
                                     ip: '127.0.0.1',
                                     platform: 'Web',
                                     country: 'United States',
-                                    insert_id: 'bestId')
+                                    insert_id: 'bestId',
+                                    session_id: 'mySessionId')
       end
 
       it 'accepts symbol attributes' do
@@ -82,7 +84,8 @@ describe AmplitudeAPI::Event do
           ip: '127.0.0.1',
           platform: 'Web',
           country: 'United States',
-          insert_id: 'bestId'
+          insert_id: 'bestId',
+          session_id: 'mySessionId'
         )
 
         expect(event.to_hash).to eq(event_type: 'sausage',
@@ -94,7 +97,8 @@ describe AmplitudeAPI::Event do
                                     ip: '127.0.0.1',
                                     platform: 'Web',
                                     country: 'United States',
-                                    insert_id: 'bestId')
+                                    insert_id: 'bestId',
+                                    session_id: 'mySessionId')
       end
     end
 


### PR DESCRIPTION
We may want to continue a session when send events from Ruby. It's trivial enough to get the current session id from javascript and provide that to ruby so the session stays continuous.