### PR TITLE
Set min id length

### DIFF
--- a/lib/amplitude_api.rb
+++ b/lib/amplitude_api.rb
@@ -72,7 +72,8 @@ class AmplitudeAPI
 
       JSON.generate(
         api_key: api_key,
-        events: event_body
+        events: event_body,
+        options: { min_id_length: 1 }
       )
     end
 

--- a/lib/amplitude_api.rb
+++ b/lib/amplitude_api.rb
@@ -9,7 +9,7 @@ class AmplitudeAPI
   require_relative 'amplitude_api/event'
   require_relative 'amplitude_api/identification'
 
-  TRACK_URI_STRING        = 'https://api.amplitude.com/httpapi'
+  TRACK_URI_STRING        = 'https://api2.amplitude.com/2/httpapi'
   IDENTIFY_URI_STRING     = 'https://api.amplitude.com/identify'
   SEGMENTATION_URI_STRING = 'https://amplitude.com/api/2/events/segmentation'
   DELETION_URI_STRING     = 'https://amplitude.com/api/2/deletions/users'
@@ -70,10 +70,10 @@ class AmplitudeAPI
     def track_body(*events)
       event_body = events.flatten.map(&:to_hash)
 
-      {
+      JSON.generate(
         api_key: api_key,
-        event: JSON.generate(event_body)
-      }
+        events: event_body
+      )
     end
 
     # @overload track(event)
@@ -86,7 +86,7 @@ class AmplitudeAPI
     #
     # Send one or more Events to the Amplitude API
     def track(*events)
-      Typhoeus.post(TRACK_URI_STRING, body: track_body(events))
+      Typhoeus.post(TRACK_URI_STRING, headers: { 'Content-Type' => 'application/json' }, body: track_body(events))
     end
 
     # ==== Identification related methods
@@ -185,7 +185,7 @@ class AmplitudeAPI
         DELETION_URI_STRING,
         userpwd: "#{api_key}:#{config.secret_key}",
         body: delete_body(user_ids, amplitude_ids, requester),
-        headers: { 'Content-Type': 'application/json' }
+        headers: { 'Content-Type' => 'application/json' }
       )
     end
 

--- a/spec/lib/amplitude_api_spec.rb
+++ b/spec/lib/amplitude_api_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 describe AmplitudeAPI do
   let(:user) { Struct.new(:id).new(123) }
   let(:device_id) { 'abcdef' }
+  let(:headers) { { 'Content-Type' => 'application/json' } }
 
   describe '.track' do
     context 'with a single event' do
@@ -14,12 +15,12 @@ describe AmplitudeAPI do
             user_id: 123,
             event_type: 'clicked on sign up'
           )
-          body = {
+          body = JSON.generate(
             api_key: described_class.api_key,
-            event: JSON.generate([event.to_hash])
-          }
+            events: [event.to_hash]
+          )
 
-          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, body: body)
+          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
 
           described_class.track(event)
         end
@@ -31,12 +32,12 @@ describe AmplitudeAPI do
             device_id: device_id,
             event_type: 'clicked on sign up'
           )
-          body = {
+          body = JSON.generate(
             api_key: described_class.api_key,
-            event: JSON.generate([event.to_hash])
-          }
+            events: [event.to_hash]
+          )
 
-          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, body: body)
+          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
 
           described_class.track(event)
         end
@@ -49,12 +50,12 @@ describe AmplitudeAPI do
             device_id: device_id,
             event_type: 'clicked on sign up'
           )
-          body = {
+          body = JSON.generate(
             api_key: described_class.api_key,
-            event: JSON.generate([event.to_hash])
-          }
+            events: [event.to_hash]
+          )
 
-          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, body: body)
+          expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
 
           described_class.track(event)
         end
@@ -71,12 +72,12 @@ describe AmplitudeAPI do
           user_id: 456,
           event_type: 'liked a widget'
         )
-        body = {
+        body = JSON.generate(
           api_key: described_class.api_key,
-          event: JSON.generate([event.to_hash, event2.to_hash])
-        }
+          events: [event.to_hash, event2.to_hash]
+        )
 
-        expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, body: body)
+        expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
 
         described_class.track([event, event2])
       end
@@ -388,7 +389,7 @@ describe AmplitudeAPI do
           AmplitudeAPI::DELETION_URI_STRING,
           userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
           body: JSON.generate(body),
-          headers: { 'Content-Type': 'application/json' }
+          headers: { 'Content-Type' => 'application/json' }
         )
         described_class.delete(user_ids: '123')
       end
@@ -405,7 +406,7 @@ describe AmplitudeAPI do
           AmplitudeAPI::DELETION_URI_STRING,
           userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
           body: JSON.generate(body),
-          headers: { 'Content-Type': 'application/json' }
+          headers: { 'Content-Type' => 'application/json' }
         )
         described_class.delete(user_ids: user_ids)
       end
@@ -423,7 +424,7 @@ describe AmplitudeAPI do
             AmplitudeAPI::DELETION_URI_STRING,
             userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
             body: JSON.generate(body),
-            headers: { 'Content-Type': 'application/json' }
+            headers: { 'Content-Type' => 'application/json' }
           )
           described_class.delete(
             amplitude_ids: amplitude_ids,
@@ -444,7 +445,7 @@ describe AmplitudeAPI do
           AmplitudeAPI::DELETION_URI_STRING,
           userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
           body: JSON.generate(body),
-          headers: { 'Content-Type': 'application/json' }
+          headers: { 'Content-Type' => 'application/json' }
         )
         described_class.delete(amplitude_ids: amplitude_ids)
       end
@@ -460,7 +461,7 @@ describe AmplitudeAPI do
           AmplitudeAPI::DELETION_URI_STRING,
           userpwd: "#{described_class.api_key}:#{described_class.config.secret_key}",
           body: JSON.generate(body),
-          headers: { 'Content-Type': 'application/json' }
+          headers: { 'Content-Type' => 'application/json' }
         )
         described_class.delete(amplitude_ids: 122)
       end
@@ -480,7 +481,7 @@ describe AmplitudeAPI do
           AmplitudeAPI::DELETION_URI_STRING,
           userpwd: userpwd,
           body: JSON.generate(body),
-          headers: { 'Content-Type': 'application/json' }
+          headers: { 'Content-Type' => 'application/json' }
         )
         described_class.delete(
           amplitude_ids: amplitude_ids,
@@ -499,7 +500,7 @@ describe AmplitudeAPI do
           test_property: 1
         }
       )
-      body = described_class.track_body(event)
+      body = JSON.parse(described_class.track_body(event), symbolize_names: true)
       expect(body[:api_key]).to eq('stub api key')
     end
 
@@ -530,7 +531,7 @@ describe AmplitudeAPI do
           ip: '8.8.8.8'
         }
       ]
-      expect(JSON.parse(body[:event], symbolize_names: true)).to eq(expected)
+      expect(JSON.parse(body, symbolize_names: true)[:events]).to eq(expected)
     end
   end
 end

--- a/spec/lib/amplitude_api_spec.rb
+++ b/spec/lib/amplitude_api_spec.rb
@@ -17,7 +17,8 @@ describe AmplitudeAPI do
           )
           body = JSON.generate(
             api_key: described_class.api_key,
-            events: [event.to_hash]
+            events: [event.to_hash],
+            options: { min_id_length: 1 }
           )
 
           expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
@@ -34,7 +35,8 @@ describe AmplitudeAPI do
           )
           body = JSON.generate(
             api_key: described_class.api_key,
-            events: [event.to_hash]
+            events: [event.to_hash],
+            options: { min_id_length: 1 }
           )
 
           expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
@@ -52,7 +54,8 @@ describe AmplitudeAPI do
           )
           body = JSON.generate(
             api_key: described_class.api_key,
-            events: [event.to_hash]
+            events: [event.to_hash],
+            options: { min_id_length: 1 }
           )
 
           expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
@@ -74,7 +77,8 @@ describe AmplitudeAPI do
         )
         body = JSON.generate(
           api_key: described_class.api_key,
-          events: [event.to_hash, event2.to_hash]
+          events: [event.to_hash, event2.to_hash],
+          options: { min_id_length: 1 }
         )
 
         expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)


### PR DESCRIPTION
Sets a min id length of 1. We have mostly uuids but some tracking ids remain as old legacy user ids, which can be of length <5. Amplitude by default errors in this case https://help.amplitude.com/hc/en-us/articles/360032842391-HTTP-API-V2#device-ids-and-user-ids-minimum-length 

