### PR TITLE
Extand Faraday Version

### DIFF
--- a/amplitude-api.gemspec
+++ b/amplitude-api.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.12.2"
   spec.add_development_dependency "rake", "~> 12.0", ">= 12.0"
   spec.add_development_dependency "rspec", "~> 2.99", ">= 2.99.0"
-  spec.add_dependency "faraday", "~> 1.0"
+  spec.add_dependency "faraday", ">= 1.0", "<= 2.2.0"
   spec.required_ruby_version = ">= 2.4"
 end


### PR DESCRIPTION
Now available Faraday [2.2.0](https://github.com/lostisland/faraday/releases/tag/v2.2.0). 
Let's update dependency ;)