### PR TITLE
fix: Use new API endpoints

### DIFF
--- a/lib/amplitude_api.rb
+++ b/lib/amplitude_api.rb
@@ -9,8 +9,8 @@ class AmplitudeAPI
   require_relative "amplitude_api/event"
   require_relative "amplitude_api/identification"
 
-  TRACK_URI_STRING        = "https://api.amplitude.com/2/httpapi"
-  IDENTIFY_URI_STRING     = "https://api.amplitude.com/identify"
+  TRACK_URI_STRING        = "https://api2.amplitude.com/2/httpapi"
+  IDENTIFY_URI_STRING     = "https://api2.amplitude.com/identify"
   SEGMENTATION_URI_STRING = "https://amplitude.com/api/2/events/segmentation"
   DELETION_URI_STRING     = "https://amplitude.com/api/2/deletions/users"
 


### PR DESCRIPTION
Replace `api.amplitude.com` with `api2.amplitude.com` as per Amplitude's documentation. Both endpoints work the same though:

    API_KEY="..."

    test_identify() {
      local endpoint="https://$1/identify"
      echo "*** ${endpoint}"

      curl "${endpoint}" \
        --data "api_key=${API_KEY}" \
        --data 'identification=[{"user_id":"x-testing-api-user"}]'
    }

    test_track() {
      local endpoint="https://$1/2/httpapi"
      echo "*** ${endpoint}"

      curl --request POST "${endpoint}" \
        --header "Content-Type: application/json" \
        --data '{"api_key":"'"${API_KEY}"'","events":[{"user_id":"x-testing-api-user","event_type":"x-testing-api-event-type"}]}'
    }

    test_identify "api.amplitude.com"
    test_identify "api2.amplitude.com"

    test_track "api.amplitude.com"
    test_track "api2.amplitude.com"