### PR TITLE
Add _some_ Behavioural Cohort methods to AmplitudeAPI

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "amplitude-api"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/lib/amplitude_api.rb
+++ b/lib/amplitude_api.rb
@@ -281,7 +281,7 @@ class AmplitudeAPI
 
     def connection_with_basic_auth
       Faraday.new do |conn|
-        conn.request :authorization, :basic, config.api_key, config.secret_key
+        conn.request :basic_auth, config.api_key, config.secret_key
       end
     end
   end

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,37 @@ AmplitudeAPI.delete(user_ids: ["12345"],
 )
 ```
 
+
+## Behavioural Cohorts APIs
+
+See the [Amplitude docs on Behavioural Cohorts](https://www.docs.developers.amplitude.com/analytics/apis/behavioral-cohorts-api).
+
+```ruby
+# Configure your Amplitude API key & secret key
+AmplitudeAPI.config.api_key = "abcdef123456"
+AmplitudeAPI.config.secret_key = "secretMcSecret"
+
+# Get all cohorts
+response = AmplitudeAPI.get_cohorts
+
+if response.status == 200
+  data = JSON.parse(response.body)
+
+  # print the ID & name of each cohort
+  data['cohorts'].each { |c| puts "id=#{c['id']} name=#{c['name']}" }
+end
+
+# Add / remove users from a cohort
+# You need to use the same user_ids you use when identifying users with the identify API
+
+# Incrementally add users to a cohort
+AmplitudeAPI.add_to_cohort(cohort_id: 'abcd123', user_ids: ['1234', '5678'])
+
+# Incrementally remove users from a cohort
+AmplitudeAPI.add_to_cohort(cohort_id: 'abcd123', user_ids: ['1234', '5678'])
+```
+
+
 Currently, we are using this in Rails and using ActiveJob to dispatch events asynchronously. I plan on moving
 background/asynchronous support into this gem.
 


### PR DESCRIPTION
https://www.docs.developers.amplitude.com/analytics/apis/behavioral-cohorts-api/

Adds 3x new methods to `AmplitudeAPI`:
- `get_cohorts` - gets all Behavioural Cohorts, returns the data in the Faraday response object - a basic example of using this API and parsing the response has been added to the README
- `add_to_cohort` - adds a list of users to a specific Behavioural Cohort
- `remove_from_cohort` - removes a list of users from a specific Behavioural Cohort

_Other changes_

- Factored out the call to get a connection with basic auth to a private helper, so it can be re-used in the new Behavioural Cohort methods
- Added a `bin/console` script to make it slightly easier to manually run the gem code in an IRB session